### PR TITLE
이미지 등록 / 수정 변경사항 반영

### DIFF
--- a/lib/common/router/router_service.dart
+++ b/lib/common/router/router_service.dart
@@ -207,7 +207,7 @@ class RouterService {
                       path: 'manage/edit',
                       builder: (context, state) => ChangeNotifierProvider(
                         create: (_) => UpdateStudyViewModel(
-                            getIt<StudyService>(), getIt<ImageUpdateService>()),
+                            getIt<StudyService>(), getIt<ImageUpdateService>(), context),
                         child: StudyUpdateScreen(
                             studyId:
                                 int.parse(state.pathParameters['studyId']!)),

--- a/lib/model/create/new_study_info_model.dart
+++ b/lib/model/create/new_study_info_model.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 class NewStudyInfo {
   String studyName;
   int max;
@@ -7,7 +5,7 @@ class NewStudyInfo {
   String password;
   String explanation;
   List<int> categories;
-  int studyImage;
+  String? uuid;
 
   NewStudyInfo({
     required this.studyName,
@@ -16,7 +14,7 @@ class NewStudyInfo {
     required this.password,
     required this.explanation,
     required this.categories,
-    required this.studyImage,
+    required this.uuid,
   });
 
   Map<String, dynamic> toJson() {
@@ -27,7 +25,7 @@ class NewStudyInfo {
       'password': password,
       'explanation': explanation,
       'categories': categories,
-      "studyImage" : studyImage,
+      'uuid': uuid,
     };
   }
 }

--- a/lib/service/create/study_create_service.dart
+++ b/lib/service/create/study_create_service.dart
@@ -32,7 +32,7 @@ class StudyCreateService {
       String password,
       String explanation,
       List<int> categories,
-      int studyImage) async {
+      String uuid) async {
     Map<String, dynamic> studyCreateDtoJson = NewStudyInfo(
       studyName: studyName,
       max: max,
@@ -40,7 +40,7 @@ class StudyCreateService {
       password: password,
       explanation: explanation,
       categories: categories,
-      studyImage: studyImage,
+      uuid: uuid,
     ).toJson();
 
     try {

--- a/lib/service/image/image_create_service.dart
+++ b/lib/service/image/image_create_service.dart
@@ -14,7 +14,7 @@ abstract class ImageCreateApi {
   @POST("/images")
   @MultiPart()
   @Headers({'Content-Type': 'multipart/form-data'})
-  Future<int> create(
+  Future<String> create(
     @Part(name: "image") File image,
   );
 }
@@ -25,7 +25,7 @@ class ImageCreateService {
 
   ImageCreateService(this._api);
 
-  Future<int> callImageCreateApi(
+  Future<String> callImageCreateApi(
     File image,
   ) async {
     try {

--- a/lib/service/image/image_create_service.g.dart
+++ b/lib/service/image/image_create_service.g.dart
@@ -19,7 +19,7 @@ class _ImageCreateApi implements ImageCreateApi {
   String? baseUrl;
 
   @override
-  Future<int> create(File image) async {
+  Future<String> create(File image) async {
     const _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{r'Content-Type': 'multipart/form-data'};
@@ -32,7 +32,7 @@ class _ImageCreateApi implements ImageCreateApi {
         filename: image.path.split(Platform.pathSeparator).last,
       ),
     ));
-    final _result = await _dio.fetch<int>(_setStreamType<int>(Options(
+    final _result = await _dio.fetch<String>(_setStreamType<String>(Options(
       method: 'POST',
       headers: _headers,
       extra: _extra,

--- a/lib/service/image/image_update_service.dart
+++ b/lib/service/image/image_update_service.dart
@@ -10,12 +10,11 @@ part 'image_update_service.g.dart';
 abstract class ImageUpdateApi {
   factory ImageUpdateApi(Dio dio, {String baseUrl}) = _ImageUpdateApi;
 
-  @PATCH("/studies/{study_id}/images") // 추후 수정 필요
+  @PATCH("/images")
   @MultiPart()
   @Headers({'Content-Type': 'multipart/form-data'})
-  Future<int> update(
-    @Path("study_id") int studyId,
-    @Part(name: "study_image") File image,
+  Future<String> update(
+    @Part(name: "image") File image,
   );
 }
 
@@ -25,13 +24,11 @@ class ImageUpdateService {
 
   ImageUpdateService(this._api);
 
-  Future<int> callImageUpdateApi(
-    int studyId,
+  Future<String> callImageUpdateApi(
     File image,
   ) async {
     try {
       final response = await _api.update(
-        studyId,
         image,
       );
       return response;

--- a/lib/service/image/image_update_service.g.dart
+++ b/lib/service/image/image_update_service.g.dart
@@ -19,23 +19,20 @@ class _ImageUpdateApi implements ImageUpdateApi {
   String? baseUrl;
 
   @override
-  Future<int> update(
-    int studyId,
-    File image,
-  ) async {
+  Future<String> update(File image) async {
     const _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{r'Content-Type': 'multipart/form-data'};
     _headers.removeWhere((k, v) => v == null);
     final _data = FormData();
     _data.files.add(MapEntry(
-      'study_image',
+      'image',
       MultipartFile.fromFileSync(
         image.path,
         filename: image.path.split(Platform.pathSeparator).last,
       ),
     ));
-    final _result = await _dio.fetch<int>(_setStreamType<int>(Options(
+    final _result = await _dio.fetch<String>(_setStreamType<String>(Options(
       method: 'PATCH',
       headers: _headers,
       extra: _extra,
@@ -43,7 +40,7 @@ class _ImageUpdateApi implements ImageUpdateApi {
     )
         .compose(
           _dio.options,
-          '/studies/${studyId}/images',
+          '/images',
           queryParameters: queryParameters,
           data: _data,
         )

--- a/lib/view_models/study/create_study_viewmodel.dart
+++ b/lib/view_models/study/create_study_viewmodel.dart
@@ -38,7 +38,7 @@ class CreateStudyViewModel extends StudyInfoViewModel with ChangeNotifier {
   String _studyDescription = '';
   String _studyDisclosePassword = '';
   int _studyMemberCount = 0;
-  int? _studyImageId;
+  String? _studyImageUuid;
   int? _studyId;
 
   int? get studyId => _studyId;
@@ -149,7 +149,7 @@ class CreateStudyViewModel extends StudyInfoViewModel with ChangeNotifier {
   @override
   Future<void> callImageApi() async {
     if (_studyImageFile != null) {
-      _studyImageId =
+      _studyImageUuid =
       await _imageCreateService.callImageCreateApi(_studyImageFile!);
     }
     notifyListeners();
@@ -176,7 +176,7 @@ class CreateStudyViewModel extends StudyInfoViewModel with ChangeNotifier {
         _studyDisclosePassword,
         _studyDescription,
         _selectedCategoryIndices..sort(),
-        _studyImageId!,
+        _studyImageUuid!,
       );
       _studyId = newStudy.id;
     } on StudyImageException catch (e) {}

--- a/lib/view_models/study/model/updated_study_info.dart
+++ b/lib/view_models/study/model/updated_study_info.dart
@@ -3,9 +3,10 @@ class UpdatedStudyInfo {
   final String? explanation;
   final List<int>? categories;
   final int? max;
+  final String? uuid;
 
-  UpdatedStudyInfo( this.studyName, this.explanation,
-      this.categories, this.max);
+  UpdatedStudyInfo(
+      this.studyName, this.explanation, this.categories, this.max, this.uuid);
 
   Map<String, dynamic> toJson() {
     return {
@@ -13,6 +14,7 @@ class UpdatedStudyInfo {
       'max': max,
       'explanation': explanation,
       'categories': categories,
+      'uuid': uuid
     };
   }
 }


### PR DESCRIPTION
**이미지 등록, 수정 api (create, update) (path: ../service/image)**
: 기존 스터디 이미지만 등록, 수정에서 유저/스터디 모두 사용 가능하도록 공통화. (클래스 명도 변경) & imageId가 아닌 String의 uuid 리턴

**Url 변경**
- 등록/수정 모두 '/images'로 변경

**Request form 변경사항**
- name (study_image -> image)
- 수정 api의 경우 url의 study_id @path 프로퍼티 삭제

**Response form 변경사항**
- name[type] (studyImageId [int]-> uuid[String])

**사용**
- ImageCreateService / ImageUpdateService 추가 후,  callImageCreateApi / callImageUpdateApi 호출, 파라미터로 File 객체 전달